### PR TITLE
Improve GitLab setup flow UI and fix OAuth redirect URL issue

### DIFF
--- a/packages/probot/lib/apps/setup.js
+++ b/packages/probot/lib/apps/setup.js
@@ -89,6 +89,7 @@ const setupAppFactory = (host, port) => async function setupApp(app, { getRouter
     const route = getRouter();
     route.use((0, logging_middleware_1.getLoggingMiddleware)(app.log));
     route.use(body_parser_1.default.urlencoded({ extended: true }));
+    route.use(body_parser_1.default.json());
     
     // Clean up expired sessions every hour
     setInterval(() => {
@@ -132,9 +133,21 @@ const setupAppFactory = (host, port) => async function setupApp(app, { getRouter
                     <h2>Quick Links:</h2>
                     <ul>
                         <li><a href="/probot">Start Setup Flow</a> - Normal setup flow</li>
+                        <li><a href="/probot/vcs-selection">VCS Selection</a> - Choose between GitHub and GitLab</li>
                         <li><a href="/probot/tunnel-config">Tunnel Configuration</a> - Configure tunnel settings</li>
-                        <li><a href="/probot/app-setup">App Setup Page</a> - App creation form</li>
-                        <li><a href="/probot/success">Success Page (Dev Mode)</a> - Direct access to success page with mock data</li>
+                        <li><strong>GitHub Flow:</strong>
+                            <ul>
+                                <li><a href="/probot/app-setup">App Setup Page</a> - GitHub app creation form</li>
+                                <li><a href="/probot/success">Success Page (Dev Mode)</a> - Direct access to success page with mock data</li>
+                            </ul>
+                        </li>
+                        <li><strong>GitLab Flow:</strong>
+                            <ul>
+                                <li><a href="/probot/gitlab-pat-setup">GitLab PAT Setup</a> - Configure bot account PAT</li>
+                                <li><a href="/probot/gitlab-manual-setup">GitLab Manual Setup</a> - Manual app creation instructions</li>
+                                <li><a href="/probot/gitlab-success">GitLab Success</a> - Environment variables display</li>
+                            </ul>
+                        </li>
                     </ul>
                     
                     <h2>How to use:</h2>
@@ -152,8 +165,12 @@ const setupAppFactory = (host, port) => async function setupApp(app, { getRouter
             res.status(404).send('Development mode is not enabled. Set TERRATEAM_DEV_MODE=true to enable.');
         }
     });
+    route.get("/probot/vcs-selection", async (req, res) => {
+        // VCS provider selection screen
+        res.render("vcs-selection.handlebars");
+    });
     route.get("/probot/tunnel-config", async (req, res) => {
-        // Second screen - tunnel configuration
+        // Third screen - tunnel configuration
         const sessionId = getSessionId(req);
         res.render("tunnel-config.handlebars", { sessionId });
     });
@@ -452,8 +469,21 @@ const setupAppFactory = (host, port) => async function setupApp(app, { getRouter
         }
         res.json({ success: true });
     });
+    route.get("/probot/gitlab-pat-setup", async (req, res) => {
+        // GitLab PAT setup screen
+        res.render("gitlab-pat-setup.handlebars");
+    });
+    route.get("/probot/gitlab-manual-setup", async (req, res) => {
+        // GitLab manual app creation screen
+        res.render("gitlab-manual-setup.handlebars");
+    });
+    route.get("/probot/gitlab-success", async (req, res) => {
+        // GitLab success screen
+        res.render("gitlab-success.handlebars");
+    });
+    // Removed gitlab-app-create endpoint - we go directly to manual setup since API creation requires admin permissions
     route.get("/probot/app-setup", async (req, res) => {
-        // Second screen - GitHub app creation
+        // GitHub app creation screen
         const baseUrl = getBaseUrl(req);
         const pkg = setup.pkg;
         const manifest = setup.getManifest(pkg, baseUrl);

--- a/packages/probot/static/terrateam-setup.css
+++ b/packages/probot/static/terrateam-setup.css
@@ -1713,4 +1713,96 @@ code {
     font-size: 1.27rem;
   }
 }
+
+/* VCS Selection styles */
+.vcs-options {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  margin: 2rem 0 3rem 0;
+  flex-wrap: wrap;
+}
+
+.vcs-option-card {
+  position: relative;
+  border: 2px solid #e1e4e8;
+  border-radius: 12px;
+  padding: 0;
+  transition: all 0.3s ease;
+  background: #fff;
+  cursor: pointer;
+  width: 280px;
+}
+
+.vcs-option-card:hover {
+  border-color: #009BFF;
+  box-shadow: 0 4px 12px rgba(0, 155, 255, 0.1);
+  transform: translateY(-2px);
+}
+
+.vcs-option-card:has(.vcs-radio:checked) {
+  border-color: #009BFF;
+  background: #f8fbff;
+  box-shadow: 0 6px 20px rgba(0, 155, 255, 0.15);
+}
+
+.vcs-radio {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.vcs-option-label {
+  display: block;
+  padding: 2.5rem 2rem;
+  cursor: pointer;
+  position: relative;
+  text-align: center;
+}
+
+.vcs-option-label::before {
+  content: '';
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  width: 24px;
+  height: 24px;
+  border: 2px solid #d1d5da;
+  border-radius: 50%;
+  background: #fff;
+  transition: all 0.2s ease;
+}
+
+.vcs-radio:checked + .vcs-option-label::before {
+  border-color: #009BFF;
+  background: #009BFF;
+  box-shadow: inset 0 0 0 4px #fff;
+}
+
+.vcs-option-label .option-header {
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.vcs-icon {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto;
+}
+
+.vcs-option-label .option-title {
+  font-size: 2rem;
+  font-weight: 600;
+  color: #24292e;
+  margin: 0;
+}
+
+.vcs-option-label .option-description {
+  color: #586069;
+  font-size: 1.25rem;
+  line-height: 1.4;
+  margin: 0;
+}
 EOF < /dev/null

--- a/packages/probot/views/app-setup.handlebars
+++ b/packages/probot/views/app-setup.handlebars
@@ -13,20 +13,21 @@
       <div class="setup-container">
          <div class="setup-card">
             <img src="/probot/static/logo.svg" alt="Terrateam Logo" class="logo">
-            <h1 class="app-setup-title">Create GitHub App</h1>
-            <h2 class="setup-subtitle">Let's create your private GitHub app</h2>
+            <h1 class="app-setup-title">Create <span id="vcs-app-name">GitHub</span> App</h1>
+            <h2 class="setup-subtitle">Let's create your private <span id="vcs-app-name2">GitHub</span> app</h2>
             <div class="progress-indicator">
                <div class="progress-step completed">1. Welcome</div>
-               <div class="progress-step completed">2. Configure Access</div>
-               <div class="progress-step active">3. Create App</div>
-               <div class="progress-step">4. Complete</div>
+               <div class="progress-step completed">2. Choose VCS</div>
+               <div class="progress-step completed">3. Configure Access</div>
+               <div class="progress-step active">4. Create App</div>
+               <div class="progress-step">5. Complete</div>
             </div>
             <p class="setup-description">This will enable Terrateam to work with your repositories.</p>
             <div class="divider"></div>
                
             <div class="form-section">
-               <label for="github-org" class="form-label">GitHub Organization <span class="optional-text">(optional)</span></label>
-               <input type="text" id="github-org" name="github-org" class="form-input" placeholder="Leave blank for personal account" value="{{ orgName }}">
+               <label for="vcs-org" class="form-label"><span id="vcs-org-label">GitHub</span> Organization <span class="optional-text">(optional)</span></label>
+               <input type="text" id="vcs-org" name="vcs-org" class="form-input" placeholder="Leave blank for personal account" value="{{ orgName }}">
                
                <div class="checkbox-container">
                   <input type="checkbox" id="onboarding-call" name="onboarding-call" class="checkbox-input" checked>
@@ -61,10 +62,29 @@
       </div>
       
       <script>
+         // Get VCS provider from session storage and update UI
+         const vcsProvider = sessionStorage.getItem('vcsProvider') || 'github';
+         const vcsDisplayName = vcsProvider === 'gitlab' ? 'GitLab' : 'GitHub';
+         
+         // Update VCS provider references in the UI
+         document.getElementById('vcs-app-name').textContent = vcsDisplayName;
+         document.getElementById('vcs-app-name2').textContent = vcsDisplayName;
+         document.getElementById('vcs-org-label').textContent = vcsDisplayName;
+         
+         // Show warning for GitLab since it's not fully implemented yet
+         if (vcsProvider === 'gitlab') {
+            const setupCard = document.querySelector('.setup-card');
+            const warningDiv = document.createElement('div');
+            warningDiv.className = 'warning-box';
+            warningDiv.style.cssText = 'background: #fff3cd; border: 1px solid #ffc107; border-radius: 8px; padding: 1rem; margin: 1rem 0; color: #856404;';
+            warningDiv.innerHTML = '<strong>⚠️ Note:</strong> GitLab App creation is not yet implemented in this setup wizard. You will need to manually create a GitLab application. <a href="https://docs.gitlab.com/ee/integration/oauth_provider.html" target="_blank">See GitLab OAuth documentation</a>.';
+            setupCard.insertBefore(warningDiv, setupCard.querySelector('.form-section'));
+         }
+         
          document.getElementById('create-app-form').addEventListener('submit', function(e) {
             e.preventDefault();
             
-            const orgInput = document.getElementById('github-org');
+            const orgInput = document.getElementById('vcs-org');
             const onboardingInput = document.getElementById('onboarding-call');
             
             const orgValue = orgInput.value.trim();

--- a/packages/probot/views/gitlab-manual-setup.handlebars
+++ b/packages/probot/views/gitlab-manual-setup.handlebars
@@ -1,0 +1,429 @@
+<!DOCTYPE html>
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
+   <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta http-equiv="X-UA-Compatible" content="ie=edge">
+      <title>Terrateam Setup - Manual GitLab App Creation</title>
+      <link rel="icon" href="/probot/static/logo.svg">
+      <link rel="stylesheet" href="/probot/static/primer.css">
+      <link rel="stylesheet" href="/probot/static/terrateam-setup.css">
+   </head>
+   <body>
+      <div class="setup-container">
+         <div class="setup-card">
+            <img src="/probot/static/logo.svg" alt="Terrateam Logo" class="logo">
+            <h1 class="setup-title">Create GitLab Application</h1>
+            <h2 class="setup-subtitle">Manually configure OAuth application</h2>
+            <div class="progress-indicator">
+               <div class="progress-step completed">1. Welcome</div>
+               <div class="progress-step completed">2. Choose VCS</div>
+               <div class="progress-step completed">3. Configure Access</div>
+               <div class="progress-step active">4. GitLab Setup</div>
+               <div class="progress-step">5. Complete</div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">1</div>
+                  <h3 class="step-title">Create OAuth Application</h3>
+               </div>
+               <p class="step-description">Follow these steps to create an OAuth application in GitLab.</p>
+               
+               <div class="step-content">
+                  <div class="step-list">
+                     <div class="step-item">
+                        <span class="step-bullet">1.</span>
+                        <span>Sign in to GitLab as the bot account</span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">2.</span>
+                        <span>Go to <strong>User Avatar → Preferences → Applications</strong></span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">3.</span>
+                        <span>Click <strong>"Add new application"</strong></span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">4.</span>
+                        <span>Configure with these exact settings:</span>
+                     </div>
+                  </div>
+                  
+                  <div class="token-requirements">
+                     <div class="requirement-item">
+                        <span class="requirement-label">Name:</span>
+                        <code>Terrateam</code>
+                     </div>
+                     <div class="requirement-item">
+                        <span class="requirement-label">Redirect URI:</span>
+                        <div class="copy-field">
+                           <input type="text" id="redirect-url" readonly class="copy-input" value="Loading...">
+                           <button class="copy-btn" onclick="copyToClipboard('redirect-url')">Copy</button>
+                        </div>
+                     </div>
+                     <div class="requirement-item">
+                        <span class="requirement-label">Scopes:</span>
+                        <span class="scope-checkbox">✓ api</span> (required)
+                     </div>
+                  </div>
+                  
+                  <div class="step-list" style="margin-top: 1rem;">
+                     <div class="step-item">
+                        <span class="step-bullet">5.</span>
+                        <span>Click <strong>"Save application"</strong></span>
+                     </div>
+                     <div class="step-item important">
+                        <span class="step-bullet">6.</span>
+                        <span><strong>Copy the Application ID and Secret immediately</strong> - keep this page open!</span>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">2</div>
+                  <h3 class="step-title">Enter Application Credentials</h3>
+               </div>
+               
+               <label for="app-id" class="form-label">Application ID <span style="color: #e3342f;">*</span></label>
+               <input type="text" id="app-id" name="app-id" class="form-input" 
+                      placeholder="e.g., 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd" required>
+               
+               <label for="app-secret" class="form-label">Application Secret <span style="color: #e3342f;">*</span></label>
+               <input type="password" id="app-secret" name="app-secret" class="form-input" 
+                      placeholder="Paste your application secret here" required>
+            </div>
+            
+            <button type="button" id="continue-btn" class="btn-primary">Continue</button>
+            
+            <div class="navigation-footer">
+               <button type="button" id="back-btn" class="btn-text">← Back to PAT Setup</button>
+            </div>
+         </div>
+         <div class="support-section">
+            <h4 class="support-title">Support</h4>
+            <div class="support-links">
+               <a href="https://terrateam.io/docs/" class="support-link">Docs</a>
+               <a href="https://terrateam.io/slack" class="support-link">Slack</a>
+               <a href="https://github.com/terrateamio/terrateam" class="support-link">GitHub</a>
+               <a href="mailto:support@terrateam.io" class="support-link">Email</a>
+            </div>
+         </div>
+      </div>
+      
+      <!-- Fixed help link -->
+      <div class="fixed-help">
+         <a href="https://terrateam.io/slack" class="fixed-help-link" target="_blank">
+            Need help? Join Slack
+         </a>
+      </div>
+      
+      <script>
+         
+         // Get and display redirect URL
+         const gitlabConfig = JSON.parse(sessionStorage.getItem('gitlabConfig') || '{}');
+         const redirectUrlInput = document.getElementById('redirect-url');
+         
+         if (gitlabConfig.redirectUrl) {
+            redirectUrlInput.value = gitlabConfig.redirectUrl;
+         } else {
+            // Fallback if no redirect URL is found
+            const tunnelConfig = JSON.parse(sessionStorage.getItem('tunnelConfig') || '{}');
+            if (tunnelConfig.serverHostname) {
+               const protocol = tunnelConfig.serverHostname.includes('localhost') ? 'http' : 'https';
+               redirectUrlInput.value = `${protocol}://${tunnelConfig.serverHostname}/api/v1/gitlab/callback`;
+            } else {
+               redirectUrlInput.value = 'Error: No redirect URL found';
+            }
+         }
+         
+         function copyToClipboard(elementId) {
+            const element = document.getElementById(elementId);
+            element.select();
+            document.execCommand('copy');
+            
+            // Visual feedback
+            const button = element.nextElementSibling;
+            const originalText = button.textContent;
+            button.textContent = 'Copied!';
+            setTimeout(() => {
+               button.textContent = originalText;
+            }, 2000);
+         }
+         
+         document.getElementById('continue-btn').addEventListener('click', function(e) {
+            e.preventDefault();
+            
+            const appId = document.getElementById('app-id').value.trim();
+            const appSecret = document.getElementById('app-secret').value.trim();
+            
+            if (!appId) {
+               alert('Please enter the Application ID');
+               return;
+            }
+            
+            if (!appSecret) {
+               alert('Please enter the Application Secret');
+               return;
+            }
+            
+            // Store credentials
+            sessionStorage.setItem('gitlabAppCredentials', JSON.stringify({
+               id: appId,
+               secret: appSecret,
+               manual: true
+            }));
+            
+            // Proceed to success screen
+            window.location.href = '/probot/gitlab-success';
+         });
+         
+         document.getElementById('back-btn').addEventListener('click', function() {
+            window.location.href = '/probot/gitlab-pat-setup';
+         });
+      </script>
+      
+      <style>
+         .setup-section {
+            margin-bottom: 2.5rem;
+         }
+         
+         .step-header {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 0.75rem;
+         }
+         
+         .step-number {
+            background: #009BFF;
+            color: white;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 1.125rem;
+            flex-shrink: 0;
+         }
+         
+         .step-title {
+            margin: 0;
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #24292e;
+         }
+         
+         .step-description {
+            color: #586069;
+            font-size: 1.25rem;
+            line-height: 1.6;
+            margin: 0 0 1rem 3rem;
+         }
+         
+         .step-content {
+            margin-left: 3rem;
+            background: #f8f9fa;
+            border: 1px solid #d1d5da;
+            border-radius: 8px;
+            padding: 2rem;
+         }
+         
+         .step-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+         }
+         
+         .step-item {
+            display: flex;
+            gap: 0.875rem;
+            align-items: flex-start;
+            line-height: 1.6;
+            color: #24292e;
+            font-size: 1.125rem;
+         }
+         
+         .step-item.important {
+            background: #fff8c5;
+            border: 1px solid #f9c513;
+            border-radius: 6px;
+            padding: 1rem;
+            margin-top: 0.75rem;
+            color: #735c0f;
+            font-weight: 500;
+            font-size: 1.25rem;
+         }
+         
+         .step-bullet {
+            color: #0366d6;
+            font-weight: 700;
+            width: 2rem;
+            flex-shrink: 0;
+            font-size: 1.125rem;
+         }
+         
+         .token-requirements {
+            background: white;
+            border: 2px solid #0366d6;
+            border-radius: 6px;
+            padding: 1.5rem;
+            margin: 1.25rem 0 0 2.875rem;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+         }
+         
+         .requirement-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 0.75rem 0;
+            color: #24292e;
+            font-size: 1.125rem;
+         }
+         
+         .requirement-item:not(:last-child) {
+            border-bottom: 1px solid #eaecef;
+         }
+         
+         .requirement-label {
+            color: #24292e;
+            font-weight: 600;
+            min-width: 120px;
+            font-size: 1.125rem;
+         }
+         
+         .scope-checkbox {
+            background: #28a745;
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 4px;
+            font-size: 1rem;
+            font-weight: 600;
+         }
+         
+         code {
+            background: #f3f4f6;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 1rem;
+            color: #e36209;
+         }
+         
+         .step-item strong {
+            color: #24292e;
+            font-weight: 600;
+            background: #fff3cd;
+            padding: 0.25rem 0.375rem;
+            border-radius: 3px;
+         }
+         
+         /* Copy field specific styling */
+         .copy-field {
+            display: flex;
+            gap: 0.5rem;
+            flex: 1;
+         }
+         
+         .copy-input {
+            flex: 1;
+            padding: 0.375rem 0.75rem;
+            border: 1px solid #d1d5da;
+            border-radius: 4px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875rem;
+            background: white;
+            color: #24292e;
+         }
+         
+         .copy-btn {
+            padding: 0.375rem 0.875rem;
+            background: #0366d6;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 600;
+            white-space: nowrap;
+            transition: background-color 0.2s;
+         }
+         
+         .copy-btn:hover {
+            background: #0256c7;
+         }
+         
+         /* Info box styling */
+         .info-box {
+            background: #f0f9ff;
+            border: 1px solid #0ea5e9;
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+         }
+         
+         .info-box-title {
+            color: #0369a1;
+            font-size: 1.125rem;
+            font-weight: 600;
+            margin: 0 0 0.75rem 0;
+         }
+         
+         .info-box-text {
+            color: #0369a1;
+            font-size: 1rem;
+            margin: 0 0 0.75rem 0;
+            line-height: 1.5;
+         }
+         
+         .info-box-list {
+            margin: 0;
+            padding-left: 1.5rem;
+            color: #0369a1;
+         }
+         
+         .info-box-list li {
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+            line-height: 1.5;
+         }
+         
+         .info-box-list code {
+            background: white;
+            padding: 0.125rem 0.375rem;
+            border-radius: 3px;
+            font-size: 0.875rem;
+            color: #0369a1;
+            font-weight: 600;
+         }
+         
+         /* Responsive */
+         @media (max-width: 768px) {
+            .copy-field {
+               flex-direction: column;
+            }
+            
+            .copy-btn {
+               width: 100%;
+            }
+            
+            .step-description {
+               margin-left: 0;
+            }
+            
+            .step-content {
+               margin-left: 0;
+               padding: 1.5rem;
+            }
+            
+            .token-requirements {
+               margin-left: 0;
+            }
+         }
+      </style>
+   </body>
+</html>

--- a/packages/probot/views/gitlab-pat-setup.handlebars
+++ b/packages/probot/views/gitlab-pat-setup.handlebars
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
+   <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta http-equiv="X-UA-Compatible" content="ie=edge">
+      <title>Terrateam Setup - GitLab Configuration</title>
+      <link rel="icon" href="/probot/static/logo.svg">
+      <link rel="stylesheet" href="/probot/static/primer.css">
+      <link rel="stylesheet" href="/probot/static/terrateam-setup.css">
+   </head>
+   <body>
+      <div class="setup-container">
+         <div class="setup-card">
+            <img src="/probot/static/logo.svg" alt="Terrateam Logo" class="logo">
+            <h1 class="setup-title">Configure GitLab Bot Account</h1>
+            <h2 class="setup-subtitle">Set up a bot account for Terrateam</h2>
+            <div class="progress-indicator">
+               <div class="progress-step completed">1. Welcome</div>
+               <div class="progress-step completed">2. Choose VCS</div>
+               <div class="progress-step completed">3. Configure Access</div>
+               <div class="progress-step active">4. GitLab Setup</div>
+               <div class="progress-step">5. Complete</div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">1</div>
+                  <h3 class="step-title">Create a GitLab Bot Account</h3>
+               </div>
+               <p class="step-description">Terrateam needs a dedicated bot account to interact with your GitLab instance.</p>
+               
+               <div class="step-content">
+                  <p class="step-intro">If you don't have a bot account yet:</p>
+                  <div class="step-list">
+                     <div class="step-item">
+                        <span class="step-bullet">1.</span>
+                        <span>Create a new GitLab user account for Terrateam</span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">2.</span>
+                        <span>Use a descriptive name like <strong>"acme-terrateam-bot"</strong></span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">3.</span>
+                        <span>Use a dedicated email address for this bot account</span>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">2</div>
+                  <h3 class="step-title">Create a Personal Access Token</h3>
+               </div>
+               <p class="step-description">Generate a Personal Access Token (PAT) for the bot account with API access.</p>
+               
+               <div class="step-content">
+                  <div class="step-list">
+                     <div class="step-item">
+                        <span class="step-bullet">1.</span>
+                        <span>Log in to GitLab as the bot account</span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">2.</span>
+                        <span>Go to <strong>User → Preferences → Access Tokens</strong></span>
+                     </div>
+                     <div class="step-item">
+                        <span class="step-bullet">3.</span>
+                        <span>Create a new token with:</span>
+                     </div>
+                  </div>
+                  
+                  <div class="token-requirements">
+                     <div class="requirement-item">
+                        <span class="requirement-label">Name:</span>
+                        <code>terrateam</code>
+                     </div>
+                     <div class="requirement-item">
+                        <span class="requirement-label">Expiration:</span>
+                        <strong>Maximum allowed</strong> (365 days or no expiration)
+                     </div>
+                     <div class="requirement-item">
+                        <span class="requirement-label">Scope:</span>
+                        <span class="scope-checkbox">✓ api</span> (required)
+                     </div>
+                  </div>
+                  
+                  <div class="step-list" style="margin-top: 1rem;">
+                     <div class="step-item">
+                        <span class="step-bullet">4.</span>
+                        <span>Click <strong>"Create token"</strong></span>
+                     </div>
+                     <div class="step-item important">
+                        <span class="step-bullet">5.</span>
+                        <span><strong>Copy the token immediately</strong> - it won't be shown again!</span>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">3</div>
+                  <h3 class="step-title">Enter Bot Account Details</h3>
+               </div>
+               
+               <label for="gitlab-url" class="form-label">GitLab Instance URL</label>
+               <input type="url" id="gitlab-url" name="gitlab-url" class="form-input" 
+                      placeholder="https://gitlab.com" value="https://gitlab.com">
+               
+               <label for="gitlab-pat" class="form-label">Personal Access Token <span style="color: #e3342f;">*</span></label>
+               <input type="password" id="gitlab-pat" name="gitlab-pat" class="form-input" 
+                      placeholder="glpat-xxxxxxxxxxxxxxxxxxxx" required>
+            </div>
+
+            <button type="button" id="continue-btn" class="btn-primary">Continue to Manual Setup</button>
+            
+            <div class="navigation-footer">
+               <button type="button" id="back-btn" class="btn-text">← Back to Access Configuration</button>
+            </div>
+         </div>
+         <div class="support-section">
+            <h4 class="support-title">Support</h4>
+            <div class="support-links">
+               <a href="https://terrateam.io/docs/" class="support-link">Docs</a>
+               <a href="https://terrateam.io/slack" class="support-link">Slack</a>
+               <a href="https://github.com/terrateamio/terrateam" class="support-link">GitHub</a>
+               <a href="mailto:support@terrateam.io" class="support-link">Email</a>
+            </div>
+         </div>
+      </div>
+      
+      <!-- Fixed help link -->
+      <div class="fixed-help">
+         <a href="https://terrateam.io/slack" class="fixed-help-link" target="_blank">
+            Need help? Join Slack
+         </a>
+      </div>
+      
+      <script>
+         document.getElementById('continue-btn').addEventListener('click', function(e) {
+            e.preventDefault();
+            
+            const gitlabUrl = document.getElementById('gitlab-url').value.trim();
+            const gitlabPat = document.getElementById('gitlab-pat').value.trim();
+            
+            // Validation
+            if (!gitlabUrl) {
+               alert('Please enter your GitLab instance URL');
+               return;
+            }
+            
+            if (!gitlabPat) {
+               alert('Please enter the Personal Access Token');
+               return;
+            }
+            
+            // Get tunnel configuration
+            const tunnelConfig = JSON.parse(sessionStorage.getItem('tunnelConfig') || '{}');
+            
+            // Determine redirect URL based on tunnel configuration
+            let redirectUrl;
+            if (tunnelConfig.needsTunnel && tunnelConfig.tunnelCredentials) {
+               // tunnel_url already contains just the domain without protocol
+               redirectUrl = `https://${tunnelConfig.tunnelCredentials.tunnel_url}/api/v1/gitlab/callback`;
+            } else if (tunnelConfig.serverHostname) {
+               // Check if serverHostname already has protocol
+               if (tunnelConfig.serverHostname.startsWith('http://') || tunnelConfig.serverHostname.startsWith('https://')) {
+                  redirectUrl = `${tunnelConfig.serverHostname}/api/v1/gitlab/callback`;
+               } else {
+                  redirectUrl = `https://${tunnelConfig.serverHostname}/api/v1/gitlab/callback`;
+               }
+            } else {
+               alert('Error: No server hostname or tunnel URL found. Please go back and configure access.');
+               return;
+            }
+            
+            // Store GitLab configuration
+            sessionStorage.setItem('gitlabConfig', JSON.stringify({
+               gitlabUrl: gitlabUrl,
+               gitlabPat: gitlabPat,
+               redirectUrl: redirectUrl
+            }));
+            
+            // Go directly to manual setup
+            // (Creating apps via API requires admin permissions that most users don't have)
+            window.location.href = '/probot/gitlab-manual-setup';
+         });
+         
+         document.getElementById('back-btn').addEventListener('click', function() {
+            window.location.href = '/probot/tunnel-config';
+         });
+         
+         // Pre-fill GitLab URL if we have it from OAuth
+         const tunnelConfig = JSON.parse(sessionStorage.getItem('tunnelConfig') || '{}');
+         if (tunnelConfig.gitlabUrl) {
+            document.getElementById('gitlab-url').value = tunnelConfig.gitlabUrl;
+         }
+      </script>
+      
+      <style>
+         .setup-section {
+            margin-bottom: 2.5rem;
+         }
+         
+         .step-header {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 0.75rem;
+         }
+         
+         .step-number {
+            background: #009BFF;
+            color: white;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 1.125rem;
+            flex-shrink: 0;
+         }
+         
+         .step-title {
+            margin: 0;
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #24292e;
+         }
+         
+         .step-description {
+            color: #586069;
+            font-size: 1.25rem;
+            line-height: 1.6;
+            margin: 0 0 1rem 3rem;
+         }
+         
+         .step-content {
+            margin-left: 3rem;
+            background: #f8f9fa;
+            border: 1px solid #d1d5da;
+            border-radius: 8px;
+            padding: 2rem;
+         }
+         
+         .step-intro {
+            color: #24292e;
+            margin: 0 0 1.25rem 0;
+            font-size: 1.25rem;
+            font-weight: 500;
+         }
+         
+         .step-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+         }
+         
+         .step-item {
+            display: flex;
+            gap: 0.875rem;
+            align-items: flex-start;
+            line-height: 1.6;
+            color: #24292e;
+            font-size: 1.125rem;
+         }
+         
+         .step-item.important {
+            background: #fff8c5;
+            border: 1px solid #f9c513;
+            border-radius: 6px;
+            padding: 1rem;
+            margin-top: 0.75rem;
+            color: #735c0f;
+            font-weight: 500;
+            font-size: 1.25rem;
+         }
+         
+         .step-bullet {
+            color: #0366d6;
+            font-weight: 700;
+            width: 2rem;
+            flex-shrink: 0;
+            font-size: 1.125rem;
+         }
+         
+         .token-requirements {
+            background: white;
+            border: 2px solid #0366d6;
+            border-radius: 6px;
+            padding: 1.5rem;
+            margin: 1.25rem 0 0 2.875rem;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+         }
+         
+         .requirement-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 0.75rem 0;
+            color: #24292e;
+            font-size: 1.125rem;
+         }
+         
+         .requirement-item:not(:last-child) {
+            border-bottom: 1px solid #eaecef;
+         }
+         
+         .requirement-label {
+            color: #24292e;
+            font-weight: 600;
+            min-width: 120px;
+            font-size: 1.125rem;
+         }
+         
+         .scope-checkbox {
+            background: #28a745;
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 4px;
+            font-size: 1rem;
+            font-weight: 600;
+         }
+         
+         code {
+            background: #f3f4f6;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 1rem;
+            color: #e36209;
+         }
+         
+         .step-item strong {
+            color: #24292e;
+            font-weight: 600;
+            background: #fff3cd;
+            padding: 0.25rem 0.375rem;
+            border-radius: 3px;
+         }
+         
+         .requirement-item strong {
+            font-size: 1.125rem;
+         }
+      </style>
+   </body>
+</html>

--- a/packages/probot/views/gitlab-success.handlebars
+++ b/packages/probot/views/gitlab-success.handlebars
@@ -1,0 +1,466 @@
+<!DOCTYPE html>
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
+   <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta http-equiv="X-UA-Compatible" content="ie=edge">
+      <title>Terrateam Setup - Success</title>
+      <link rel="icon" href="/probot/static/logo.svg">
+      <link rel="stylesheet" href="/probot/static/primer.css">
+      <link rel="stylesheet" href="/probot/static/terrateam-setup.css">
+   </head>
+   <body>
+      <div class="setup-container">
+         <div class="setup-card">
+            <img src="/probot/static/logo.svg" alt="Terrateam Logo" class="logo">
+            <h1 class="setup-title">Setup Complete!</h1>
+            <h2 class="setup-subtitle">Your GitLab configuration is ready</h2>
+            <div class="progress-indicator">
+               <div class="progress-step completed">1. Welcome</div>
+               <div class="progress-step completed">2. Choose VCS</div>
+               <div class="progress-step completed">3. Configure Access</div>
+               <div class="progress-step completed">4. GitLab Setup</div>
+               <div class="progress-step active">5. Complete</div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">1</div>
+                  <h3 class="step-title">Copy Environment Variables</h3>
+               </div>
+               <p class="step-description">Add these variables to your <code>.env</code> file in your Terrateam directory.</p>
+               
+               <div class="step-content">
+                  <textarea id="env-vars" class="env-textarea" readonly></textarea>
+                  <button class="copy-env-btn" onclick="copyEnvVars()">Copy All</button>
+               </div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">2</div>
+                  <h3 class="step-title">Start Terrateam</h3>
+               </div>
+               <p class="step-description">Run Terrateam using Docker Compose.</p>
+               
+               <div class="step-content">
+                  <div class="command-display">
+                     <code>docker compose up</code>
+                     <button class="copy-command-btn" onclick="copyCommand()">Copy</button>
+                  </div>
+               </div>
+            </div>
+            
+            <div class="setup-section">
+               <div class="step-header">
+                  <div class="step-number">3</div>
+                  <h3 class="step-title">Access Terrateam UI</h3>
+               </div>
+               <p class="step-description">Once Terrateam is running, access the web interface.</p>
+               
+               <div class="step-content">
+                  <div class="ui-url-display">
+                     <span class="url-label">UI URL:</span>
+                     <a id="ui-url" href="#" target="_blank" class="ui-link"></a>
+                  </div>
+                  <div class="step-note">
+                     Log in via the UI and follow the <strong>Getting Started</strong> guide to configure your repositories.
+                  </div>
+               </div>
+            </div>
+            
+            <div class="info-box">
+               <h4 class="info-box-title">⚠️ GitLab Identity Verification</h4>
+               <p class="info-box-text">If you encounter identity verification errors when running pipelines:</p>
+               <div class="info-steps">
+                  <div class="info-step"><span class="step-num">1.</span> Log in as the bot account</div>
+                  <div class="info-step"><span class="step-num">2.</span> Navigate to <strong>Project → Build → Pipelines</strong></div>
+                  <div class="info-step"><span class="step-num">3.</span> Complete the phone verification process</div>
+                  <div class="info-step"><span class="step-num">4.</span> Return to your merge request and comment: <code>terrateam plan</code></div>
+               </div>
+            </div>
+            
+            <div class="navigation-footer">
+               <a href="https://terrateam.io/docs" class="btn-secondary" target="_blank">View Documentation</a>
+               <a href="https://terrateam.io/slack" class="btn-secondary" target="_blank">Get Help</a>
+            </div>
+         </div>
+         <div class="support-section">
+            <h4 class="support-title">Support</h4>
+            <div class="support-links">
+               <a href="https://terrateam.io/docs/" class="support-link">Docs</a>
+               <a href="https://terrateam.io/slack" class="support-link">Slack</a>
+               <a href="https://github.com/terrateamio/terrateam" class="support-link">GitHub</a>
+               <a href="mailto:support@terrateam.io" class="support-link">Email</a>
+            </div>
+         </div>
+      </div>
+      
+      <!-- Fixed help link -->
+      <div class="fixed-help">
+         <a href="https://terrateam.io/slack" class="fixed-help-link" target="_blank">
+            Need help? Join Slack
+         </a>
+      </div>
+      
+      <script>
+         // Gather all configuration
+         const gitlabConfig = JSON.parse(sessionStorage.getItem('gitlabConfig') || '{}');
+         const gitlabAppCredentials = JSON.parse(sessionStorage.getItem('gitlabAppCredentials') || '{}');
+         const tunnelConfig = JSON.parse(sessionStorage.getItem('tunnelConfig') || '{}');
+         
+         // Build environment variables
+         let envVars = '';
+         
+         // GitLab credentials
+         envVars += `GITLAB_APP_ID=${gitlabAppCredentials.id || ''}\n`;
+         envVars += `GITLAB_APP_SECRET=${gitlabAppCredentials.secret || ''}\n`;
+         envVars += `GITLAB_ACCESS_TOKEN=${gitlabConfig.gitlabPat || ''}\n`;
+         
+         // UI base URL
+         if (tunnelConfig.needsTunnel && tunnelConfig.tunnelCredentials) {
+            envVars += `TERRAT_UI_BASE=https://${tunnelConfig.tunnelCredentials.tunnel_url}\n`;
+            envVars += `TERRATUNNEL_API_KEY=${tunnelConfig.tunnelCredentials.api_key}\n`;
+         } else if (tunnelConfig.serverHostname) {
+            envVars += `TERRAT_UI_BASE=https://${tunnelConfig.serverHostname}\n`;
+         }
+         
+         // GitLab instance URL if not gitlab.com
+         if (gitlabConfig.gitlabUrl && gitlabConfig.gitlabUrl !== 'https://gitlab.com') {
+            envVars += `GITLAB_BASE_URL=${gitlabConfig.gitlabUrl}\n`;
+         }
+         
+         // Display environment variables
+         document.getElementById('env-vars').value = envVars;
+         
+         // Set UI URL
+         let uiUrl = '';
+         if (tunnelConfig.needsTunnel && tunnelConfig.tunnelCredentials) {
+            uiUrl = `https://${tunnelConfig.tunnelCredentials.tunnel_url}`;
+         } else if (tunnelConfig.serverHostname) {
+            uiUrl = `https://${tunnelConfig.serverHostname}`;
+         }
+         
+         const uiLink = document.getElementById('ui-url');
+         uiLink.href = uiUrl;
+         uiLink.textContent = uiUrl;
+         
+         function copyEnvVars() {
+            const textarea = document.getElementById('env-vars');
+            textarea.select();
+            document.execCommand('copy');
+            
+            // Visual feedback
+            const button = document.querySelector('.copy-env-btn');
+            const originalText = button.textContent;
+            button.textContent = 'Copied!';
+            setTimeout(() => {
+               button.textContent = originalText;
+            }, 2000);
+         }
+         
+         function copyCommand() {
+            const tempInput = document.createElement('input');
+            tempInput.value = 'docker compose up';
+            document.body.appendChild(tempInput);
+            tempInput.select();
+            document.execCommand('copy');
+            document.body.removeChild(tempInput);
+            
+            // Visual feedback
+            const button = document.querySelector('.copy-command-btn');
+            const originalText = button.textContent;
+            button.textContent = 'Copied!';
+            setTimeout(() => {
+               button.textContent = originalText;
+            }, 2000);
+         }
+         
+         // Auto-resize textarea
+         const textarea = document.getElementById('env-vars');
+         textarea.style.height = 'auto';
+         textarea.style.height = (textarea.scrollHeight + 10) + 'px';
+      </script>
+      
+      <style>
+         .setup-section {
+            margin-bottom: 2.5rem;
+         }
+         
+         .step-header {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 0.75rem;
+         }
+         
+         .step-number {
+            background: #009BFF;
+            color: white;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 1.125rem;
+            flex-shrink: 0;
+         }
+         
+         .step-title {
+            margin: 0;
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #24292e;
+         }
+         
+         .step-description {
+            color: #586069;
+            font-size: 1.25rem;
+            line-height: 1.6;
+            margin: 0 0 1rem 3rem;
+         }
+         
+         .step-description code {
+            background: #f3f4f6;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 1rem;
+            color: #e36209;
+         }
+         
+         .step-content {
+            margin-left: 3rem;
+            background: #f8f9fa;
+            border: 1px solid #d1d5da;
+            border-radius: 8px;
+            padding: 2rem;
+            position: relative;
+         }
+         
+         .env-textarea {
+            width: 100%;
+            min-height: 120px;
+            padding: 1rem;
+            border: 1px solid #d1d5da;
+            border-radius: 6px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875rem;
+            background: white;
+            resize: vertical;
+            color: #24292e;
+         }
+         
+         .copy-env-btn {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            padding: 0.5rem 1rem;
+            background: #0366d6;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 600;
+            transition: background-color 0.2s;
+         }
+         
+         .copy-env-btn:hover {
+            background: #0256c7;
+         }
+         
+         .command-display {
+            background: white;
+            border: 2px solid #0366d6;
+            border-radius: 6px;
+            padding: 1.25rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+         }
+         
+         .command-display code {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 1.125rem;
+            color: #24292e;
+            font-weight: 600;
+         }
+         
+         .copy-command-btn {
+            padding: 0.5rem 1rem;
+            background: #0366d6;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 600;
+            white-space: nowrap;
+            transition: background-color 0.2s;
+         }
+         
+         .copy-command-btn:hover {
+            background: #0256c7;
+         }
+         
+         .ui-url-display {
+            background: white;
+            border: 2px solid #0366d6;
+            border-radius: 6px;
+            padding: 1.25rem;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+         }
+         
+         .url-label {
+            font-weight: 600;
+            color: #24292e;
+            font-size: 1.125rem;
+         }
+         
+         .ui-link {
+            color: #0366d6;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 1.125rem;
+         }
+         
+         .ui-link:hover {
+            text-decoration: underline;
+         }
+         
+         .step-note {
+            margin-top: 1.25rem;
+            color: #586069;
+            font-size: 1.125rem;
+            line-height: 1.6;
+         }
+         
+         .step-note strong {
+            color: #24292e;
+            font-weight: 600;
+         }
+         
+         /* Info box styling (warning box) */
+         .info-box {
+            background: #fff8c5;
+            border: 1px solid #f9c513;
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+         }
+         
+         .info-box-title {
+            color: #735c0f;
+            font-size: 1.125rem;
+            font-weight: 600;
+            margin: 0 0 0.75rem 0;
+         }
+         
+         .info-box-text {
+            color: #735c0f;
+            font-size: 1rem;
+            margin: 0 0 0.75rem 0;
+            line-height: 1.5;
+         }
+         
+         .info-steps {
+            margin: 0;
+         }
+         
+         .info-step {
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+            line-height: 1.5;
+            color: #735c0f;
+            display: flex;
+            gap: 0.5rem;
+         }
+         
+         .info-step:last-child {
+            margin-bottom: 0;
+         }
+         
+         .step-num {
+            font-weight: 600;
+            color: #735c0f;
+         }
+         
+         .info-step strong {
+            color: #735c0f;
+            font-weight: 600;
+         }
+         
+         .info-step code {
+            background: white;
+            padding: 0.125rem 0.375rem;
+            border-radius: 3px;
+            font-size: 0.875rem;
+            color: #735c0f;
+            font-weight: 600;
+         }
+         
+         .navigation-footer {
+            margin-top: 2rem;
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+         }
+         
+         .btn-secondary {
+            background: #f6f8fa;
+            color: #24292e;
+            border: 1px solid #d1d5da;
+            padding: 0.75rem 1.5rem;
+            border-radius: 8px;
+            font-size: 1.125rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            display: inline-block;
+         }
+         
+         .btn-secondary:hover {
+            background: #e1e4e8;
+            border-color: #c6cbd1;
+            transform: translateY(-1px);
+         }
+         
+         /* Responsive */
+         @media (max-width: 768px) {
+            .step-description {
+               margin-left: 0;
+            }
+            
+            .step-content {
+               margin-left: 0;
+               padding: 1.5rem;
+            }
+            
+            .command-display {
+               flex-direction: column;
+            }
+            
+            .ui-url-display {
+               flex-direction: column;
+               align-items: flex-start;
+            }
+            
+            .navigation-footer {
+               flex-direction: column;
+            }
+            
+            .btn-secondary {
+               width: 100%;
+               text-align: center;
+            }
+         }
+      </style>
+   </body>
+</html>

--- a/packages/probot/views/oauth-callback.handlebars
+++ b/packages/probot/views/oauth-callback.handlebars
@@ -4,7 +4,7 @@
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta http-equiv="X-UA-Compatible" content="ie=edge">
-      <title>GitHub Authentication</title>
+      <title>Authentication</title>
       <link rel="icon" href="/probot/static/logo.svg">
       <link rel="stylesheet" href="/probot/static/primer.css">
       <link rel="stylesheet" href="/probot/static/terrateam-setup.css">
@@ -87,7 +87,7 @@
             <div id="loading-state" class="callback-status">
                <div class="status-icon status-loading">⏳</div>
                <h2 class="status-title">Processing...</h2>
-               <p class="status-message">Completing GitHub authentication</p>
+               <p class="status-message">Completing authentication</p>
             </div>
             
             <div id="success-state" class="callback-status" style="display: none;">
@@ -112,14 +112,26 @@
          const error = urlParams.get('error');
          const errorDescription = urlParams.get('error_description');
          
+         // Detect VCS provider from URL, session storage, or referrer
+         const provider = urlParams.get('provider') || 
+                         sessionStorage.getItem('oauth_provider') ||
+                         (document.referrer.includes('gitlab') ? 'gitlab' : 'github');
+         const messageTypeSuccess = provider === 'gitlab' ? 'GITLAB_OAUTH_SUCCESS' : 'GITHUB_OAUTH_SUCCESS';
+         const messageTypeError = provider === 'gitlab' ? 'GITLAB_OAUTH_ERROR' : 'GITHUB_OAUTH_ERROR';
+         
+         // Clean up provider from session storage
+         sessionStorage.removeItem('oauth_provider');
+         
          // Debug logging
          console.log('OAuth Callback - Full URL:', window.location.href);
          console.log('OAuth Callback - Search params:', window.location.search);
          console.log('OAuth Callback - All params:', Object.fromEntries(urlParams));
+         console.log('OAuth Callback - Detected provider:', provider);
          console.log('OAuth Callback - code:', code);
          console.log('OAuth Callback - state:', state);
          console.log('OAuth Callback - error:', error);
          console.log('OAuth Callback - errorDescription:', errorDescription);
+         console.log('OAuth Callback - Referrer:', document.referrer);
          
          // Show appropriate state
          function showState(stateId, message = null) {
@@ -139,7 +151,7 @@
             // Send error to parent window
             if (window.opener) {
                window.opener.postMessage({
-                  type: 'GITHUB_OAUTH_ERROR',
+                  type: messageTypeError,
                   error: errorDescription || error
                }, window.location.origin);
             }
@@ -155,8 +167,13 @@
             const userLogin = urlParams.get('user_login');
             const userId = urlParams.get('user_id');
             const tunnelId = urlParams.get('tunnel_id');
-            const tunnelUrl = urlParams.get('tunnel_url');
+            let tunnelUrl = urlParams.get('tunnel_url');
             const apiKey = urlParams.get('api_key');
+            
+            // Strip protocol from tunnel URL if present (Terratunnel includes https://)
+            if (tunnelUrl && (tunnelUrl.startsWith('https://') || tunnelUrl.startsWith('http://'))) {
+               tunnelUrl = tunnelUrl.replace(/^https?:\/\//, '');
+            }
             
             if (accessToken && userLogin) {
                // Terratunnel sent tokens directly
@@ -165,12 +182,12 @@
                // Send success to parent window
                if (window.opener) {
                   window.opener.postMessage({
-                     type: 'GITHUB_OAUTH_SUCCESS',
+                     type: messageTypeSuccess,
                      token: accessToken,
                      user: {
                         login: userLogin,
                         id: parseInt(userId) || 0,
-                        avatar_url: `https://github.com/${userLogin}.png`
+                        avatar_url: provider === 'gitlab' ? `https://gitlab.com/${userLogin}.png` : `https://github.com/${userLogin}.png`
                      },
                      tunnel: tunnelId ? {
                         tunnel_id: tunnelId,
@@ -180,6 +197,23 @@
                      sessionId: sessionStorage.getItem('sessionId')
                   }, window.location.origin);
                }
+               
+               // Store in session storage for fallback
+               const storageKey = provider === 'gitlab' ? 'gitlab_oauth_result' : 'github_oauth_result';
+               sessionStorage.setItem(storageKey, JSON.stringify({
+                  success: true,
+                  token: accessToken,
+                  user: {
+                     login: userLogin,
+                     id: parseInt(userId) || 0,
+                     avatar_url: provider === 'gitlab' ? `https://gitlab.com/${userLogin}.png` : `https://github.com/${userLogin}.png`
+                  },
+                  tunnel: tunnelId ? {
+                     tunnel_id: tunnelId,
+                     tunnel_url: tunnelUrl,
+                     api_key: apiKey
+                  } : null
+               }));
                
                // Auto-close after delay
                setTimeout(() => {
@@ -212,7 +246,7 @@
                   // Send success to parent window
                   if (window.opener) {
                      window.opener.postMessage({
-                        type: 'GITHUB_OAUTH_SUCCESS',
+                        type: messageTypeSuccess,
                         token: mockResponse.access_token,
                         user: mockResponse.user,
                         tunnel: mockResponse.tunnel,
@@ -233,8 +267,13 @@
                const userLogin = urlParams.get('user_login');
                const userId = urlParams.get('user_id');
                const tunnelId = urlParams.get('tunnel_id');
-               const tunnelUrl = urlParams.get('tunnel_url');
+               let tunnelUrl = urlParams.get('tunnel_url');
                const apiKey = urlParams.get('api_key');
+               
+               // Strip protocol from tunnel URL if present (Terratunnel includes https://)
+               if (tunnelUrl && (tunnelUrl.startsWith('https://') || tunnelUrl.startsWith('http://'))) {
+                  tunnelUrl = tunnelUrl.replace(/^https?:\/\//, '');
+               }
                
                if (accessToken && userLogin) {
                   showState('success-state');
@@ -242,12 +281,12 @@
                   // Send success to parent window
                   if (window.opener) {
                      window.opener.postMessage({
-                        type: 'GITHUB_OAUTH_SUCCESS',
+                        type: messageTypeSuccess,
                         token: accessToken,
                         user: {
                            login: userLogin,
                            id: parseInt(userId) || 0,
-                           avatar_url: `https://github.com/${userLogin}.png`
+                           avatar_url: provider === 'gitlab' ? `https://gitlab.com/${userLogin}.png` : `https://github.com/${userLogin}.png`
                         },
                         tunnel: tunnelId ? {
                            tunnel_id: tunnelId,
@@ -285,7 +324,7 @@
                         // Send success to parent window
                         if (window.opener) {
                            window.opener.postMessage({
-                              type: 'GITHUB_OAUTH_SUCCESS',
+                              type: messageTypeSuccess,
                               token: data.access_token,
                               user: data.user,
                               tunnel: data.tunnel,
@@ -303,7 +342,7 @@
                         // Send error to parent window
                         if (window.opener) {
                            window.opener.postMessage({
-                              type: 'GITHUB_OAUTH_ERROR',
+                              type: messageTypeError,
                               error: data.error || 'Authentication failed'
                            }, window.location.origin);
                         }
@@ -320,7 +359,7 @@
                      // Send error to parent window
                      if (window.opener) {
                         window.opener.postMessage({
-                           type: 'GITHUB_OAUTH_ERROR',
+                           type: messageTypeError,
                            error: 'Network error occurred'
                         }, window.location.origin);
                      }
@@ -340,7 +379,7 @@
             // Send error to parent window
             if (window.opener) {
                window.opener.postMessage({
-                  type: 'GITHUB_OAUTH_ERROR',
+                  type: messageTypeError,
                   error: 'No authorization code received'
                }, window.location.origin);
             }

--- a/packages/probot/views/setup.handlebars
+++ b/packages/probot/views/setup.handlebars
@@ -17,9 +17,10 @@
             <h2 class="setup-subtitle">Get started with Terraform in minutes</h2>
             <div class="progress-indicator">
                <div class="progress-step active">1. Welcome</div>
-               <div class="progress-step">2. Configure Access</div>
-               <div class="progress-step">3. Create App</div>
-               <div class="progress-step">4. Complete</div>
+               <div class="progress-step">2. Choose VCS</div>
+               <div class="progress-step">3. Configure Access</div>
+               <div class="progress-step">4. Create App</div>
+               <div class="progress-step">5. Complete</div>
             </div>
 	    <p class="setup-description">Terrateam brings GitOps workflows to your infrastructure.</p>
             <p class="help-text">Need help? <a href="https://terrateam.io/slack" class="help-link" target="_blank">Join our Slack community</a></p>
@@ -78,8 +79,8 @@
             sessionStorage.setItem('lastName', lastNameValue);
             sessionStorage.setItem('email', emailValue);
             
-            // Navigate to tunnel configuration screen
-            window.location.href = '/probot/tunnel-config';
+            // Navigate to VCS selection screen
+            window.location.href = '/probot/vcs-selection';
          });
       </script>
    </body>

--- a/packages/probot/views/success.handlebars
+++ b/packages/probot/views/success.handlebars
@@ -17,9 +17,10 @@
             <h2 class="success-subtitle">Your GitHub Application has been created</h2>
             <div class="progress-indicator">
                <div class="progress-step completed">1. Welcome</div>
-               <div class="progress-step completed">2. Configure Access</div>
-               <div class="progress-step completed">3. Create App</div>
-               <div class="progress-step active">4. Complete</div>
+               <div class="progress-step completed">2. Choose VCS</div>
+               <div class="progress-step completed">3. Configure Access</div>
+               <div class="progress-step completed">4. Create App</div>
+               <div class="progress-step active">5. Complete</div>
             </div>
             
             <div class="next-steps-section">

--- a/packages/probot/views/tunnel-config.handlebars
+++ b/packages/probot/views/tunnel-config.handlebars
@@ -17,15 +17,16 @@
             <h2 class="setup-subtitle">How will GitHub reach your Terrateam server?</h2>
             <div class="progress-indicator">
                <div class="progress-step completed">1. Welcome</div>
-               <div class="progress-step active">2. Configure Access</div>
-               <div class="progress-step">3. Create App</div>
-               <div class="progress-step">4. Complete</div>
+               <div class="progress-step completed">2. Choose VCS</div>
+               <div class="progress-step active">3. Configure Access</div>
+               <div class="progress-step">4. Create App</div>
+               <div class="progress-step">5. Complete</div>
             </div>
-            <p class="setup-description">GitHub needs to send webhooks to your Terrateam server. Choose your setup method below.</p>
+            <p class="setup-description"><span id="vcs-provider-name">Your VCS provider</span> needs to send webhooks to your Terrateam server. Choose your setup method below.</p>
             
             <!-- Step 1: Choose webhook delivery method -->
             <div class="config-section">
-               <h3 class="section-title">How will GitHub reach your server?</h3>
+               <h3 class="section-title">How will <span class="vcs-name">your VCS provider</span> reach your server?</h3>
                <div class="tunnel-options">
                   <div class="tunnel-option-card">
                      <input type="radio" id="yes-tunnel" name="tunnel-type" value="tunnel" class="tunnel-radio" checked>
@@ -55,12 +56,19 @@
             <div id="tunnel-config" class="action-section" style="display: block;">
                <div class="action-box">
                   <h3 class="action-title">Set up your tunnel</h3>
-                  <p class="action-description">Authenticate with GitHub to provision your secure tunnel. This takes just a few seconds.</p>
-                  <button type="button" id="github-signin-btn" class="btn-primary btn-hero">
-                     <svg height="24" width="24" viewBox="0 0 16 16" class="github-icon">
+                  <p class="action-description">Authenticate with <span class="vcs-name">your VCS provider</span> to provision your secure tunnel. This takes just a few seconds.</p>
+                  <button type="button" id="vcs-signin-btn" class="btn-primary btn-hero">
+                     <svg height="24" width="24" viewBox="0 0 16 16" class="vcs-icon-btn github-icon">
                         <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
                      </svg>
-                     Authenticate with GitHub
+                     <svg height="24" width="24" viewBox="0 0 24 24" class="vcs-icon-btn gitlab-icon" style="display: none;">
+                        <path fill="#E24329" d="M12 2L2 8.5L12 22L22 8.5L12 2Z"/>
+                        <path fill="#FC6D26" d="M12 2L2 8.5L7.5 8.5L12 2Z"/>
+                        <path fill="#FC6D26" d="M12 2L22 8.5L16.5 8.5L12 2Z"/>
+                        <path fill="#FCA326" d="M2 8.5L7.5 8.5L12 22L2 8.5Z"/>
+                        <path fill="#FCA326" d="M22 8.5L16.5 8.5L12 22L22 8.5Z"/>
+                     </svg>
+                     <span id="auth-btn-text">Authenticate with GitHub</span>
                   </button>
                   <p class="action-note">This will open a secure popup window</p>
                </div>
@@ -87,12 +95,25 @@
                <div class="action-box">
                   <h3 class="action-title">Continue without tunnel</h3>
                   <p class="action-description">You'll need to configure your server's webhook URL manually in the next step.</p>
+                  
+                  <div id="gitlab-hostname-input" style="display: none; margin: 1.5rem 0;">
+                     <label for="server-hostname" class="form-label" style="display: block; margin-bottom: 0.5rem; font-weight: 600;">
+                        Server Hostname <span style="color: #e3342f;">*</span>
+                     </label>
+                     <p style="color: #586069; font-size: 0.875rem; margin-bottom: 0.75rem;">
+                        Enter the hostname where your Terrateam server will be accessible (e.g., terrateam.example.com)
+                     </p>
+                     <input type="text" id="server-hostname" name="server-hostname" class="form-input" 
+                            placeholder="terrateam.example.com" 
+                            style="width: 100%; padding: 0.75rem; font-size: 1rem; border: 1px solid #d1d5da; border-radius: 6px;">
+                  </div>
+                  
                   <button type="button" id="continue-no-tunnel" class="btn-primary btn-hero">Continue to Create App</button>
                </div>
             </div>
 
             <div class="navigation-footer">
-               <button type="button" id="back-btn" class="btn-text">← Back to Welcome</button>
+               <button type="button" id="back-btn" class="btn-text">← Back to VCS Selection</button>
             </div>
          </div>
          <div class="support-section">
@@ -118,11 +139,33 @@
          const sessionId = '{{ sessionId }}';
          sessionStorage.setItem('sessionId', sessionId);
          
+         // Get VCS provider from session storage and update UI
+         const vcsProvider = sessionStorage.getItem('vcsProvider') || 'github';
+         const vcsDisplayName = vcsProvider === 'gitlab' ? 'GitLab' : 'GitHub';
+         
+         // Update VCS provider references in the UI
+         document.getElementById('vcs-provider-name').textContent = vcsDisplayName;
+         document.querySelectorAll('.vcs-name').forEach(el => {
+            el.textContent = vcsDisplayName;
+         });
+         
+         // Update authentication button based on VCS provider
+         if (vcsProvider === 'gitlab') {
+            document.querySelector('.github-icon').style.display = 'none';
+            document.querySelector('.gitlab-icon').style.display = 'inline';
+            document.getElementById('auth-btn-text').textContent = 'Authenticate with GitLab';
+         } else {
+            document.querySelector('.github-icon').style.display = 'inline';
+            document.querySelector('.gitlab-icon').style.display = 'none';
+            document.getElementById('auth-btn-text').textContent = 'Authenticate with GitHub';
+         }
+         
          // Handle tunnel type selection (Yes/No)
          document.querySelectorAll('input[name="tunnel-type"]').forEach(radio => {
             radio.addEventListener('change', function() {
                const tunnelConfig = document.getElementById('tunnel-config');
                const noTunnelConfig = document.getElementById('no-tunnel-config');
+               const gitlabHostnameInput = document.getElementById('gitlab-hostname-input');
                
                if (this.value === 'tunnel') {
                   tunnelConfig.style.display = 'block';
@@ -130,6 +173,11 @@
                } else {
                   tunnelConfig.style.display = 'none';
                   noTunnelConfig.style.display = 'block';
+                  
+                  // Show hostname input for GitLab users not using tunnel
+                  if (vcsProvider === 'gitlab') {
+                     gitlabHostnameInput.style.display = 'block';
+                  }
                }
             });
          });
@@ -144,8 +192,8 @@
             }
          });
 
-         // Handle GitHub sign-in button
-         document.getElementById('github-signin-btn').addEventListener('click', function() {
+         // Handle VCS sign-in button
+         document.getElementById('vcs-signin-btn').addEventListener('click', function() {
             // Disable button to prevent double-clicking
             const button = this;
             button.disabled = true;
@@ -159,8 +207,12 @@
             
             sessionStorage.setItem('tunnelConfig', JSON.stringify(tunnelConfig));
             
-            // Open GitHub OAuth in popup window
-            openGitHubOAuth();
+            // Open VCS OAuth in popup window
+            if (vcsProvider === 'gitlab') {
+               openGitLabOAuth();
+            } else {
+               openGitHubOAuth();
+            }
          });
 
          function openGitHubOAuth() {
@@ -178,6 +230,10 @@
             console.log('Opening OAuth URL:', oauthUrl);
             console.log('Redirect URI:', redirectUri);
             console.log('State:', state);
+            console.log('Provider:', 'github');
+            
+            // Store provider in session for callback to detect
+            sessionStorage.setItem('oauth_provider', 'github');
             
             // Open popup window
             const popup = window.open(
@@ -211,13 +267,71 @@
             });
          }
 
+         function openGitLabOAuth() {
+            // Use Terratunnel's GitLab OAuth proxy
+            const terratunnelOAuthUrl = 'https://tunnel.terrateam.dev/auth/gitlab/authorize';
+            const redirectUri = window.location.origin + '/probot/oauth-callback';
+            
+            // Generate a simple state parameter for our callback
+            const state = Math.random().toString(36).substring(2, 15);
+            
+            // Build the OAuth URL to go through Terratunnel proxy
+            // Remove the provider parameter as it's not needed for the GitLab-specific endpoint
+            const oauthUrl = `${terratunnelOAuthUrl}?redirect_uri=${encodeURIComponent(redirectUri)}&state=${state}`;
+            
+            // Debug logging
+            console.log('Opening GitLab OAuth proxy URL:', oauthUrl);
+            console.log('Redirect URI:', redirectUri);
+            console.log('State:', state);
+            
+            // Store provider in session for callback to detect
+            sessionStorage.setItem('oauth_provider', 'gitlab');
+            
+            // IMPORTANT: Make sure we're opening the Terratunnel proxy URL, not GitLab directly
+            console.log('About to open popup with URL:', oauthUrl);
+            
+            // Open popup window
+            const popup = window.open(
+               oauthUrl,
+               'gitlab-oauth',
+               'width=600,height=700,scrollbars=yes,resizable=yes,status=yes,location=yes,toolbar=no,menubar=no'
+            );
+            
+            // Monitor popup for completion
+            const checkClosed = setInterval(function() {
+               if (popup.closed) {
+                  clearInterval(checkClosed);
+                  // Check if authentication was successful
+                  checkOAuthResult();
+               }
+            }, 1000);
+            
+            // Handle message from popup
+            window.addEventListener('message', function(event) {
+               if (event.origin !== window.location.origin) return;
+               
+               if (event.data.type === 'GITLAB_OAUTH_SUCCESS') {
+                  clearInterval(checkClosed);
+                  popup.close();
+                  handleOAuthSuccess(event.data);
+               } else if (event.data.type === 'GITLAB_OAUTH_ERROR') {
+                  clearInterval(checkClosed);
+                  popup.close();
+                  handleOAuthError(event.data.error);
+               }
+            });
+         }
 
          function checkOAuthResult() {
-            // Check session storage for OAuth result
-            const oauthResult = sessionStorage.getItem('github_oauth_result');
+            // Check session storage for OAuth result (works for both GitHub and GitLab)
+            const githubResult = sessionStorage.getItem('github_oauth_result');
+            const gitlabResult = sessionStorage.getItem('gitlab_oauth_result');
+            const oauthResult = githubResult || gitlabResult;
+            
             if (oauthResult) {
                const result = JSON.parse(oauthResult);
                sessionStorage.removeItem('github_oauth_result');
+               sessionStorage.removeItem('gitlab_oauth_result');
                
                if (result.success) {
                   handleOAuthSuccess(result);
@@ -239,21 +353,28 @@
             
             if (data.tunnel) {
                tunnelConfig.tunnelCredentials = data.tunnel;
-               showOAuthStatus('success', 'GitHub authentication successful! Tunnel configured: ' + data.tunnel.tunnel_url);
+               const vcsName = vcsProvider === 'gitlab' ? 'GitLab' : 'GitHub';
+               showOAuthStatus('success', `${vcsName} authentication successful! Tunnel configured: ` + data.tunnel.tunnel_url);
             } else {
-               showOAuthStatus('success', 'GitHub authentication successful! Setting up your tunnel...');
+               const vcsName = vcsProvider === 'gitlab' ? 'GitLab' : 'GitHub';
+               showOAuthStatus('success', `${vcsName} authentication successful! Setting up your tunnel...`);
             }
             
             sessionStorage.setItem('tunnelConfig', JSON.stringify(tunnelConfig));
             
-            // Proceed to app setup after brief delay
+            // Proceed to appropriate next screen after brief delay
             setTimeout(() => {
-               window.location.href = '/probot/app-setup';
+               if (vcsProvider === 'gitlab') {
+                  window.location.href = '/probot/gitlab-pat-setup';
+               } else {
+                  window.location.href = '/probot/app-setup';
+               }
             }, 2000);
          }
 
          function handleOAuthError(error) {
-            showOAuthStatus('error', 'GitHub authentication failed: ' + (error || 'Unknown error'));
+            const vcsName = vcsProvider === 'gitlab' ? 'GitLab' : 'GitHub';
+            showOAuthStatus('error', `${vcsName} authentication failed: ` + (error || 'Unknown error'));
             reEnableAuthButton();
          }
 
@@ -277,7 +398,7 @@
          }
 
          function reEnableAuthButton() {
-            const button = document.getElementById('github-signin-btn');
+            const button = document.getElementById('vcs-signin-btn');
             if (button) {
                button.disabled = false;
                button.classList.remove('disabled');
@@ -286,20 +407,43 @@
 
          // Handle navigation
          document.getElementById('back-btn').addEventListener('click', function() {
-            window.location.href = '/probot';
+            window.location.href = '/probot/vcs-selection';
          });
 
          // Handle continue without tunnel button
          document.getElementById('continue-no-tunnel').addEventListener('click', function() {
-            // Store tunnel configuration in session storage
-            const tunnelConfig = {
-               needsTunnel: false
-            };
+            // For GitLab without tunnel, validate hostname
+            if (vcsProvider === 'gitlab') {
+               const hostnameInput = document.getElementById('server-hostname');
+               const hostname = hostnameInput ? hostnameInput.value.trim() : '';
+               
+               if (!hostname) {
+                  alert('Please enter your server hostname');
+                  hostnameInput.focus();
+                  return;
+               }
+               
+               // Store tunnel configuration with hostname
+               const tunnelConfig = {
+                  needsTunnel: false,
+                  serverHostname: hostname
+               };
+               
+               sessionStorage.setItem('tunnelConfig', JSON.stringify(tunnelConfig));
+               
+               // Navigate to GitLab PAT setup screen
+               window.location.href = '/probot/gitlab-pat-setup';
+            } else {
+               // GitHub flow - continue as before
+               const tunnelConfig = {
+                  needsTunnel: false
+               };
 
-            sessionStorage.setItem('tunnelConfig', JSON.stringify(tunnelConfig));
-            
-            // Navigate to app setup screen
-            window.location.href = '/probot/app-setup';
+               sessionStorage.setItem('tunnelConfig', JSON.stringify(tunnelConfig));
+               
+               // Navigate to app setup screen
+               window.location.href = '/probot/app-setup';
+            }
          });
       </script>
    </body>

--- a/packages/probot/views/vcs-selection.handlebars
+++ b/packages/probot/views/vcs-selection.handlebars
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
+   <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta http-equiv="X-UA-Compatible" content="ie=edge">
+      <title>Terrateam Setup - Choose VCS Provider</title>
+      <link rel="icon" href="/probot/static/logo.svg">
+      <link rel="stylesheet" href="/probot/static/primer.css">
+      <link rel="stylesheet" href="/probot/static/terrateam-setup.css">
+   </head>
+   <body>
+      <div class="setup-container">
+         <div class="setup-card">
+            <img src="/probot/static/logo.svg" alt="Terrateam Logo" class="logo">
+            <h1 class="setup-title">Choose Your VCS Provider</h1>
+            <h2 class="setup-subtitle">Select where your code repositories are hosted</h2>
+            <div class="progress-indicator">
+               <div class="progress-step completed">1. Welcome</div>
+               <div class="progress-step active">2. Choose VCS</div>
+               <div class="progress-step">3. Configure Access</div>
+               <div class="progress-step">4. Create App</div>
+               <div class="progress-step">5. Complete</div>
+            </div>
+            <p class="setup-description">Terrateam supports both GitHub and GitLab. Choose your version control system below.</p>
+            
+            <div class="vcs-options">
+               <div class="vcs-option-card">
+                  <input type="radio" id="github-vcs" name="vcs-provider" value="github" class="vcs-radio" checked>
+                  <label for="github-vcs" class="vcs-option-label">
+                     <div class="option-header">
+                        <svg height="48" width="48" viewBox="0 0 16 16" class="vcs-icon">
+                           <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                        </svg>
+                        <div class="option-title">GitHub</div>
+                     </div>
+                     <div class="option-description">Use GitHub or GitHub Enterprise Server</div>
+                  </label>
+               </div>
+               
+               <div class="vcs-option-card">
+                  <input type="radio" id="gitlab-vcs" name="vcs-provider" value="gitlab" class="vcs-radio">
+                  <label for="gitlab-vcs" class="vcs-option-label">
+                     <div class="option-header">
+                        <svg height="48" width="48" viewBox="0 0 24 24" class="vcs-icon">
+                           <path fill="#E24329" d="M12 2L2 8.5L12 22L22 8.5L12 2Z"/>
+                           <path fill="#FC6D26" d="M12 2L2 8.5L7.5 8.5L12 2Z"/>
+                           <path fill="#FC6D26" d="M12 2L22 8.5L16.5 8.5L12 2Z"/>
+                           <path fill="#FCA326" d="M2 8.5L7.5 8.5L12 22L2 8.5Z"/>
+                           <path fill="#FCA326" d="M22 8.5L16.5 8.5L12 22L22 8.5Z"/>
+                        </svg>
+                        <div class="option-title">GitLab</div>
+                     </div>
+                     <div class="option-description">Use GitLab or self-hosted GitLab</div>
+                  </label>
+               </div>
+            </div>
+
+            <button type="button" id="next-btn" class="btn-primary">Next</button>
+            
+            <div class="navigation-footer">
+               <button type="button" id="back-btn" class="btn-text">← Back to Welcome</button>
+            </div>
+         </div>
+         <div class="support-section">
+            <h4 class="support-title">Support</h4>
+            <div class="support-links">
+               <a href="https://terrateam.io/docs/" class="support-link">Docs</a>
+               <a href="https://terrateam.io/slack" class="support-link">Slack</a>
+               <a href="https://github.com/terrateamio/terrateam" class="support-link">GitHub</a>
+               <a href="mailto:support@terrateam.io" class="support-link">Email</a>
+            </div>
+         </div>
+      </div>
+      
+      <!-- Fixed help link -->
+      <div class="fixed-help">
+         <a href="https://terrateam.io/slack" class="fixed-help-link" target="_blank">
+            Need help? Join Slack
+         </a>
+      </div>
+      
+      <script>
+         document.getElementById('next-btn').addEventListener('click', function(e) {
+            e.preventDefault();
+            
+            // Get selected VCS provider
+            const selectedVcs = document.querySelector('input[name="vcs-provider"]:checked').value;
+            
+            // Store VCS provider in session storage
+            sessionStorage.setItem('vcsProvider', selectedVcs);
+            
+            // Navigate to tunnel configuration screen
+            window.location.href = '/probot/tunnel-config';
+         });
+         
+         document.getElementById('back-btn').addEventListener('click', function() {
+            window.location.href = '/probot';
+         });
+      </script>
+   </body>
+</html>


### PR DESCRIPTION
- Add VCS selection screen to choose between GitHub and GitLab
- Create dedicated GitLab setup screens matching GitHub flow styling
- Fix double https:// in redirect URL by stripping protocol from tunnel_url
- Polish GitLab manual setup screen with clear numbered steps and visual isolation
- Update GitLab success screen to match PAT setup screen layout
- Fix numbered list alignment in GitLab identity verification warning
- Improve tunnel configuration screen with better visual hierarchy
- Add proper GitLab OAuth handling in tunnel config screen

🤖 Generated with [Claude Code](https://claude.ai/code)