### PR TITLE
Remove GITLAB_BASE_URL from GitLab success view environment variables

### DIFF
--- a/packages/probot/views/gitlab-success.handlebars
+++ b/packages/probot/views/gitlab-success.handlebars
@@ -125,11 +125,6 @@
             envVars += `TERRAT_UI_BASE=https://${tunnelConfig.serverHostname}\n`;
          }
          
-         // GitLab instance URL if not gitlab.com
-         if (gitlabConfig.gitlabUrl && gitlabConfig.gitlabUrl !== 'https://gitlab.com') {
-            envVars += `GITLAB_BASE_URL=${gitlabConfig.gitlabUrl}\n`;
-         }
-         
          // Display environment variables
          document.getElementById('env-vars').value = envVars;
          


### PR DESCRIPTION
The GITLAB_BASE_URL environment variable was being set in the success view but is not needed for the Terrateam setup. This removes the conditional logic that was adding it to the displayed environment variables.

🤖 Generated with [Claude Code](https://claude.ai/code)