### PR TITLE
Add fallback URL for GitHub success screen when UI URL is not available

### DIFF
--- a/packages/probot/lib/apps/setup.js
+++ b/packages/probot/lib/apps/setup.js
@@ -561,6 +561,11 @@ const setupAppFactory = (host, port) => async function setupApp(app, { getRouter
                     }
                 }
                 
+                // Use fallback URL if tunnelUrl is still not set (production path without tunnel)
+                if (!tunnelUrl) {
+                    tunnelUrl = 'https://terrateam.example.com';
+                }
+                
                 res.render("success.handlebars", { env_file, html_url, id, client_id, client_secret, webhook_secret, pem, tunnelUrl });
                 return;
             } catch (e) {
@@ -695,6 +700,11 @@ const setupAppFactory = (host, port) => async function setupApp(app, { getRouter
                 if (terratUiBaseMatch) {
                     tunnelUrl = terratUiBaseMatch[1];
                 }
+            }
+            
+            // Use fallback URL if tunnelUrl is still not set (production path without tunnel)
+            if (!tunnelUrl) {
+                tunnelUrl = 'https://terrateam.example.com';
             }
             
             res.render("success.handlebars", { env_file, html_url, id, client_id, client_secret, webhook_secret, pem, tunnelUrl });


### PR DESCRIPTION
When users choose the production path without configuring a tunnel, the UI URL and callback URL were displayed as empty or incomplete. This change adds a fallback to use 'https://terrateam.example.com' as a placeholder when no tunnel URL is available, ensuring the success screen always displays complete instructions.

🤖 Generated with [Claude Code](https://claude.ai/code)